### PR TITLE
Remove unnecessary input image padding

### DIFF
--- a/main_test_swin2sr.py
+++ b/main_test_swin2sr.py
@@ -68,8 +68,8 @@ def main():
         with torch.no_grad():
             # pad input image to be a multiple of window_size
             _, _, h_old, w_old = img_lq.size()
-            h_pad = (h_old // window_size + 1) * window_size - h_old
-            w_pad = (w_old // window_size + 1) * window_size - w_old
+            h_pad = (window_size - h_old % window_size) % window_size
+            w_pad = (window_size - w_old % window_size) % window_size
             img_lq = torch.cat([img_lq, torch.flip(img_lq, [2])], 2)[:, :, :h_old + h_pad, :]
             img_lq = torch.cat([img_lq, torch.flip(img_lq, [3])], 3)[:, :, :, :w_old + w_pad]
             output = test(img_lq, model, args, window_size)

--- a/predict.py
+++ b/predict.py
@@ -62,8 +62,8 @@ class Predictor(BasePredictor):
         with torch.no_grad():
             # pad input image to be a multiple of window_size
             _, _, h_old, w_old = img_lq.size()
-            h_pad = (h_old // window_size + 1) * window_size - h_old
-            w_pad = (w_old // window_size + 1) * window_size - w_old
+            h_pad = (window_size - h_old % window_size) % window_size
+            w_pad = (window_size - w_old % window_size) % window_size
             img_lq = torch.cat([img_lq, torch.flip(img_lq, [2])], 2)[
                 :, :, : h_old + h_pad, :
             ]


### PR DESCRIPTION
If an image's height/width already is a multiple of the window size, then we don't have to pad the input image. E.g., for an image of shape 256x512 and using window size of 8x8 the previous code would pad in both height and width by a full window in both dimensions (i.e., 8 pixels in height and 8 pixels in width), even though this is unnecessary. This is now removed, and for the given example the padding would be 0 in both dimensions.